### PR TITLE
Disable docstring linting and removed troublesome dependency

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,8 +7,7 @@ Readability:
         - ScopeAnalyser.check_magic_numbers_used
 Documentation:
     Comment Clarity: []
-    Informative Docstrings:
-        - DocstringAnalyser
+    Informative Docstrings: []
     Description of Logic: []
 AlgorithmicLogic:
     Single Instance of Logic: []  # TODO?

--- a/docs/analysers/docstrings.md
+++ b/docs/analysers/docstrings.md
@@ -1,5 +1,7 @@
 # Table of Contents
 
+**Currently disabled due to Python 3.10 pip bugs**
+
 * [analysers.docstrings](#analysers.docstrings)
   * [DocstringAnalyser](#analysers.docstrings.DocstringAnalyser)
     * [check\_class\_docstrings](#analysers.docstrings.DocstringAnalyser.check_class_docstrings)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,7 +8,6 @@ Analysers are classes that directly perform static analysis on the target file.
 The analysers are defined in the `analysers` package. All analysers must be subclasses 
 of the `Analyser` class in `analysers.Analyser`. There are currently 6 analysers, namely:
 * `ClassInstanceAnalyser`
-* `DocstringAnalyser`
 * `EncapsulationAnalyser`
 * `NamingAnalyser`
 * `ScopeAnalyser`

--- a/mikelint/__main__.py
+++ b/mikelint/__main__.py
@@ -2,7 +2,7 @@ import argparse
 
 from .formatters import SimpleFormatter, JsonFormatter
 from .analysers import (
-    ClassInstanceAnalyser, DocstringAnalyser,
+    ClassInstanceAnalyser,
     EncapsulationAnalyser, NamingAnalyser,
     ScopeAnalyser, StructureAnalyser
 )
@@ -20,7 +20,6 @@ def main():
     args = parser.parse_args()
     analysers = [
         ClassInstanceAnalyser,
-        DocstringAnalyser,
         EncapsulationAnalyser,
         NamingAnalyser,
         ScopeAnalyser,

--- a/mikelint/analysers/__init__.py
+++ b/mikelint/analysers/__init__.py
@@ -1,7 +1,6 @@
 """__init__"""
 from .analyser import Analyser
 from .class_instance import ClassInstanceAnalyser
-from .docstrings import DocstringAnalyser
 from .encapsulation import EncapsulationAnalyser
 from .naming import NamingAnalyser
 from .scope import ScopeAnalyser

--- a/mikelint/config.yaml
+++ b/mikelint/config.yaml
@@ -7,8 +7,7 @@ Readability:
         - ScopeAnalyser.check_magic_numbers_used
 Documentation:
     Comment Clarity: []
-    Informative Docstrings:
-        - DocstringAnalyser
+    Informative Docstrings: []
     Description of Logic: []
 Object-Oriented Program Structure:
     Classes & Instances:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 astroid==2.5.6
-docstring-parser==0.8.1
 isort==5.8.0
 lazy-object-proxy==1.6.0
 mccabe==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="mikelint",
-    version="1.2.1",
+    version="1.2.2",
     description="Linter used for CSSE1001 at UQ",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -23,7 +23,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "astroid>=2.5",
-        "docstring-parser>=0.7",
         "isort>=5.8",
         "lazy-object-proxy>=1.6",
         "mccabe>=0.6",


### PR DESCRIPTION
The docstring_parser is unable to be installed by pip in Python 3.10.
As a temporary solution I am removing the docstring analyser until a fix is released.

